### PR TITLE
add link to #help

### DIFF
--- a/mocker.go
+++ b/mocker.go
@@ -1,21 +1,19 @@
 package main
 
 import (
+	"github.com/bwmarrin/discordgo"
 	"log"
 	"time"
-
-	"github.com/bwmarrin/discordgo"
 )
 
 const (
 	FORWARD_TO = "617549691730526209"
-
 	NO_HELP_ROLE = "230803433752363020"
 )
 
 
-func canDMBot(user_id string) bool {
-	member, err := discord.GuildMember(IMPACT_SERVER, user_id)
+func canDMBot(userId string) bool {
+	member, err := discord.GuildMember(IMPACT_SERVER, userId)
 	if err != nil || member == nil {
 		return false
 	}
@@ -42,6 +40,7 @@ func onMessageSent2(session *discordgo.Session, m *discordgo.MessageCreate) {
 	if !canDMBot(author) {
 		return
 	}
+
 
 	embed := &discordgo.MessageEmbed{
 		Author:      &discordgo.MessageEmbedAuthor{},
@@ -74,7 +73,15 @@ func onMessageSent2(session *discordgo.Session, m *discordgo.MessageCreate) {
 			log.Println(err)
 		}
 		time.Sleep(2 * time.Second)
-		_, err = discord.ChannelMessageSend(ch.ID, "hey do you need some #help?")
+		reply := &discordgo.MessageEmbed{
+			Author: &discordgo.MessageEmbedAuthor{},
+			Color: prettyembedcolor,
+			Title: "Hey do you need some help?",
+			Description: "[#help](https://discordapp.com/channels/208753003996512258/222120655594848256/565925125304877056)",
+		}
+
+		// embeds are the only way. Maybe it'd be better to have a link instead, but having a #help label on the link looks nicer.
+		_, err = discord.ChannelMessageSendEmbed(ch.ID, reply)
 		if err != nil {
 			log.Println(err)
 		}


### PR DESCRIPTION
Not sure if this is good because it uses embeds and makes it look like a bot.
I don't think the people who DM the bot will understand that though.

Anyway, now #help will have a link on it :smile: 