### PR TITLE
add nickname bans to cruel censorship + clean up some things

### DIFF
--- a/const.go
+++ b/const.go
@@ -23,6 +23,7 @@ const (
 	na            = "616409814779691114"
 	oldguys       = "293796603146272768"
 	development   = "280478531346104321"
+	impactBotLog  = "617549691730526209"
 	testing       = "617066818925756506"
 )
 
@@ -35,6 +36,7 @@ var (
 	Donator   = Role{"210114021641289728", "donator"}
 	Verified  = Role{"671048798654562354", "verified"}
 	InVoice   = Role{"677329885680762904", "in voice"}
+	NoHelp    = Role{"230803433752363020", "no help"}
 )
 
 type Role struct {

--- a/cruel_censorship_enforcement.go
+++ b/cruel_censorship_enforcement.go
@@ -33,7 +33,7 @@ func onMessageUpdate(session *discordgo.Session, m *discordgo.MessageUpdate) {
 func onGuildMemberUpdate2(session *discordgo.Session, m *discordgo.GuildMemberUpdate) {
 	for _, badNick := range bannedNicks {
 		if strings.Contains(strings.ToLower(m.Nick), strings.ToLower(badNick)) {
-			resp(impactBotLog, "Note: User "+m.User.Username+" tried to change his nick to \""+m.Nick+"\", which is ILLEGAL")
+			resp(impactBotLog, "Note: User "+m.User.Username+" tried to change their nick to \""+m.Nick+"\", which is ILLEGAL")
 			session.GuildMemberNickname(IMPACT_SERVER, m.User.ID, TRASH)
 			return
 		}

--- a/cruel_censorship_enforcement.go
+++ b/cruel_censorship_enforcement.go
@@ -12,10 +12,14 @@ type Censorship struct {
 }
 
 var censor = map[string]Censorship{
-	"563138570953687061": Censorship{"Bella", []string{"kami", "blue", "力ミ", "ブル"}},
-	"209785549010108416": Censorship{"Arisa", []string{"loli", "smh"}},
-	"207833493651193856": Censorship{"XPHonza", []string{"boomer"}},
-	"297773911158816769": Censorship{"leijurv", []string{"not allowed to say this"}},
+	"563138570953687061": {"Bella", []string{"kami", "blue", "力ミ", "ブル"}},
+	"209785549010108416": {"Arisa", []string{"loli", "smh"}},
+	"207833493651193856": {"XPHonza", []string{"boomer"}},
+	"297773911158816769": {"leijurv", []string{"not allowed to say this"}},
+}
+
+var bannedNicks = []string{
+	"loli",
 }
 
 func onMessageSent3(session *discordgo.Session, m *discordgo.MessageCreate) {
@@ -24,6 +28,16 @@ func onMessageSent3(session *discordgo.Session, m *discordgo.MessageCreate) {
 
 func onMessageUpdate(session *discordgo.Session, m *discordgo.MessageUpdate) {
 	enforcement(session, m.Message)
+}
+
+func onGuildMemberUpdate2(session *discordgo.Session, m *discordgo.GuildMemberUpdate) {
+	for _, badNick := range bannedNicks {
+		if strings.Contains(strings.ToLower(m.Nick), strings.ToLower(badNick)) {
+			resp(impactBotLog, "Note: User "+m.User.Username+" tried to change his nick to \""+m.Nick+"\", which is ILLEGAL")
+			session.GuildMemberNickname(IMPACT_SERVER, m.User.ID, TRASH)
+			return
+		}
+	}
 }
 
 func enforcement(session *discordgo.Session, msg *discordgo.Message) {

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func init() {
 	discord.AddHandler(onMessageSentCommandHandler)
 	discord.AddHandler(onUserJoin2)
 	discord.AddHandler(onMessageSent3)
+	discord.AddHandler(onGuildMemberUpdate2)
 	discord.AddHandler(onMessageUpdate)
 	discord.AddHandler(onVoiceStateUpdate)
 	discord.AddHandler(onUserJoin3)

--- a/mocker.go
+++ b/mocker.go
@@ -8,17 +8,12 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-const (
-	FORWARD_TO   = "617549691730526209"
-	NO_HELP_ROLE = "230803433752363020"
-)
-
 func canDMBot(userId string) bool {
 	member, err := GetMember(userId)
 	if err != nil || member == nil {
 		return false
 	}
-	return !includes(member.Roles, NO_HELP_ROLE)
+	return !includes(member.Roles, NoHelp.ID)
 }
 
 // inform when someone DMs the bot because the messages are humorous
@@ -60,7 +55,7 @@ func onMessageSent2(session *discordgo.Session, m *discordgo.MessageCreate) {
 			Text: "from @" + msg.Author.Username + "#" + msg.Author.Discriminator,
 		},
 	}
-	_, err := session.ChannelMessageSendEmbed(FORWARD_TO, embed)
+	_, err := session.ChannelMessageSendEmbed(impactBotLog, embed)
 	if err != nil {
 		log.Println(err)
 	}

--- a/rekt.go
+++ b/rekt.go
@@ -241,7 +241,7 @@ func muteHandler(caller *discordgo.Member, msg *discordgo.Message, args []string
 		return err
 	}
 
-	_ = resp(FORWARD_TO, providedReason)
+	_ = resp(impactBotLog, providedReason)
 
 	_ = resp(msg.ChannelID, providedReason)
 	return nil
@@ -376,7 +376,7 @@ func unmuteHandler(caller *discordgo.Member, msg *discordgo.Message, args []stri
 	}
 
 	// Respond in chat & #impactbot-log
-	_ = resp(FORWARD_TO, reply.String())
+	_ = resp(impactBotLog, reply.String())
 	_ = resp(msg.ChannelID, reply.String())
 
 	return nil
@@ -428,7 +428,7 @@ func rektHandler(caller *discordgo.Member, msg *discordgo.Message, args []string
 		return err
 	}
 
-	_ = resp(FORWARD_TO, providedReason)
+	_ = resp(impactBotLog, providedReason)
 
 	_ = resp(msg.ChannelID, providedReason)
 	return nil


### PR DESCRIPTION
Removed a few unncessary statements, moved some consts to const.go, and most importantly made the word 'loli' illegal in nicknames for everyone.