### PR TITLE
Update replies.go for 1.16

### DIFF
--- a/replies.go
+++ b/replies.go
@@ -161,7 +161,7 @@ var replies = []Reply{
 	},
 	{
 		pattern: `(1\.16.*?(update|coming|support|release|impact|version|eta|when|out|support)|(update|coming|support|release|impact|version|eta|when|out|support).*?1\.16)`,
-		message: "No ETA on 1.16 Impact release, a message will be posted in <#" + announcements + "> when development starts & nightly builds.",
+		message: "No ETA on 1.16 Impact release, but it is in development. Check <#" + announcements + "> for development updates & nightly builds.",
 	},
 	{
 		pattern: `(impact.+(1\.8|1\.7))|((1\.8|1\.7).impact)`,


### PR DESCRIPTION
Updated 1.16 ETA message to inform the user that 1.16 is in development with no eta, and to check #announcements for dev updates and nightly builds.