### PR TITLE
Update replies.go for 1.16

### DIFF
--- a/replies.go
+++ b/replies.go
@@ -160,8 +160,8 @@ var replies = []Reply{
 		message: "You can mine a specific type of block(s) by typing `#mine <ID> [<ID>]` in chat.\nYou can find a list of block ID names [here](https://www.digminecraft.com/lists/)",
 	},
 	{
-		pattern: `(1\.16.*?(update|coming|support|release|impact|version|eta|when|out|support)|(update|coming|support|release|impact|version|eta|when|out|support).*?1\.16)`,
-		message: "No ETA on 1.16 Impact release, a message will be posted in <#" + announcements + "> when development starts & nightly builds.",
+		pattern: `(1\.16.*?(update|coming|support|release|impact|version|eta|when|out|support|nightly)|(update|coming|support|release|impact|version|eta|when|out|support|nightly).*?1\.16)`,
+		message: "No ETA on 1.16 Impact release, but is in development. Check <#" + announcements + "> for development updates & nightly builds.",
 	},
 	{
 		pattern: `(impact.+(1\.8|1\.7))|((1\.8|1\.7).impact)`,


### PR DESCRIPTION
Updated replies.go to include "nightly" in list of terms to respond to after "1.16". Also edited reply message now that 1.16 is supposedly in development.