### PR TITLE
Change prettyembedcolor

### DIFF
--- a/const.go
+++ b/const.go
@@ -4,7 +4,7 @@ package main
 const (
 	impactServer     = "208753003996512258"
 	brady            = "205718273696858113"
-	prettyembedcolor = 0x3498DB
+	prettyembedcolor = 0xAD7EC2
 
 	trash = "🗑"
 	check = "✅"


### PR DESCRIPTION
change the embed color the bot uses from a blue to the same purple the impact bot name uses from the support role. 
new: https://media.discordapp.net/attachments/308653317834145802/753261400771657868/unknown.png
old: https://media.discordapp.net/attachments/308653317834145802/753261973868904598/unknown.png