### PR TITLE
Add unfunny as an alias

### DIFF
--- a/command.go
+++ b/command.go
@@ -142,6 +142,7 @@ var Commands = []Command{
 	},
 	{
 		Name:        "funny",
+		Aliases:     []string{"unfunny"},
 		Description: "didnt laugh",
 		Usage:       []string{""},
 		Handler:     handleFunny,


### PR DESCRIPTION
Much of what Impcat bot pulls up with the i!funny command is not funny. As a result, the i!funny command is mostly inaccurate, therefore we need to add i!unfunny as an alias in order to preserve accuracy.