### PR TITLE
make tutorial regex BetterTM

### DIFF
--- a/replies.go
+++ b/replies.go
@@ -43,7 +43,7 @@ var replies = []Reply{
 		message: "[Please read this thread regarding Impact being flagged by antiviruses](https://github.com/ImpactDevelopment/ImpactIssues/wiki/Setup-FAQ#my-antivirus-says-the-installer-is-a-virus-is-it-a-virus)\n\n[Direct download link after adfly](https://impactdevelopment.github.io/?brady-money-grubbing-completed=true)",
 	},
 	{
-		pattern: `tutorial`,
+		pattern: `tutorial|(impact|install|download).*(on|for) (windows|linux|mac)`,
 		message: "Tutorial videos for downloading and installing the client:\n[Windows](https://www.youtube.com/watch?v=QP6CN-1JYYE)\n[Mac OSX](https://www.youtube.com/watch?v=BBO0v4eq95k)\n[Linux](https://www.youtube.com/watch?v=XPLvooJeQEI)\n",
 	},
 	{


### PR DESCRIPTION
`tutorial|(impact|install|download).*(on|for) (windows|linux|mac)`
can probably be improved but here are examples that will trigger it
```
i need help downloading for mac
how to download impact for windows
impact on linux
@bot tutorial
tutorial
impact tutorial
install impact on mac
i need help installing for linux
literally anything with the word tutorial
```