### PR TITLE
make berrely incapable of addcringe

### DIFF
--- a/cringe.go
+++ b/cringe.go
@@ -31,6 +31,9 @@ func handleAddCringe(caller *discordgo.Member, msg *discordgo.Message, args []st
 	if caller.User.ID == "488400748296667147" {
 		return fmt.Errorf("cringe vini does not get to add cringe because cringe vini himself is cringe")
 	}
+	if caller.User.ID == "162848980647018496" {
+		return fmt.Errorf("berrely is too cringe to add cringe")
+	}
 
 	if len(args) < 2 {
 		if len(msg.Attachments) > 0 {


### PR DESCRIPTION
I believe this is a very important and valuable change to make to our Impact Bot. Berrely is bri ish, which is unfortunate, but it prevents him from correctly identifying cringe. Perhaps it is the teeth, but I digress. This change solves the problem of bri ish Berrely adding improper cringe to our cringe db. 